### PR TITLE
ユーザー詳細ページを作成する

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,17 +1,12 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import * as React from "react";
-import { UserDetailsScreen, UserListScreen } from "./screens";
+import { UserData, UserDetailsScreen, UserListScreen } from "./screens";
 
 export type RootStackParamList = {
   UserListScreen: undefined;
   UserDetailsScreen: {
-    userdata: {
-      name: string | undefined;
-      thumbnail: string | undefined;
-      email: string | undefined;
-      age: string | undefined;
-    };
+    userdata: UserData | null;
   };
 };
 
@@ -30,12 +25,7 @@ const App = () => {
           name="UserDetailsScreen"
           component={UserDetailsScreen}
           initialParams={{
-            userdata: {
-              name: undefined,
-              thumbnail: undefined,
-              email: undefined,
-              age: undefined,
-            },
+            userdata: null,
           }}
           options={{ title: "UserDetails" }}
         />

--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,18 @@
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import * as React from "react";
-import { UserListScreen } from "./screens";
+import { UserDetailsScreen, UserListScreen } from "./screens";
 
 export type RootStackParamList = {
   UserListScreen: undefined;
+  UserDetailsScreen: {
+    userdata: {
+      name: string | undefined;
+      thumbnail: string | undefined;
+      email: string | undefined;
+      age: string | undefined;
+    };
+  };
 };
 
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +25,19 @@ const App = () => {
           name="UserListScreen"
           component={UserListScreen}
           options={{ title: "UserList" }}
+        />
+        <RootStack.Screen
+          name="UserDetailsScreen"
+          component={UserDetailsScreen}
+          initialParams={{
+            userdata: {
+              name: undefined,
+              thumbnail: undefined,
+              email: undefined,
+              age: undefined,
+            },
+          }}
+          options={{ title: "UserDetails" }}
         />
       </RootStack.Navigator>
     </NavigationContainer>

--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@ import { UserData, UserDetailsScreen, UserListScreen } from "./screens";
 export type RootStackParamList = {
   UserListScreen: undefined;
   UserDetailsScreen: {
-    userdata: UserData | null;
+    userdata: UserData;
   };
 };
 
@@ -24,9 +24,6 @@ const App = () => {
         <RootStack.Screen
           name="UserDetailsScreen"
           component={UserDetailsScreen}
-          initialParams={{
-            userdata: null,
-          }}
           options={{ title: "UserDetails" }}
         />
       </RootStack.Navigator>

--- a/App.tsx
+++ b/App.tsx
@@ -6,7 +6,7 @@ import { UserData, UserDetailsScreen, UserListScreen } from "./screens";
 export type RootStackParamList = {
   UserListScreen: undefined;
   UserDetailsScreen: {
-    userdata: UserData;
+    userData: UserData;
   };
 };
 

--- a/screens/UserDetailsScreen.tsx
+++ b/screens/UserDetailsScreen.tsx
@@ -17,23 +17,25 @@ export const UserDetailsScreen = (props: Props) => {
   return (
     <View style={styles.container}>
       <Image
-        source={{ uri: props.route.params.userdata.thumbnail }}
+        source={{ uri: props.route.params.userdata?.thumbnail }}
         style={{ width: 200, height: 200 }}
       />
       <View style={styles.userDetails}>
         <View style={styles.userdata}>
           <Text style={styles.label}>name:</Text>
-          <Text style={styles.text}>{props.route.params.userdata.name}</Text>
+          <Text style={styles.text}>{props.route.params.userdata?.name}</Text>
         </View>
         <View style={styles.userdata}>
           <Text style={styles.label}>email:</Text>
           <Text style={styles.text}>
-            email:{props.route.params.userdata.email}
+            email:{props.route?.params?.userdata?.email}
           </Text>
         </View>
         <View style={styles.userdata}>
           <Text style={styles.label}>age:</Text>
-          <Text style={styles.text}>age:{props.route.params.userdata.age}</Text>
+          <Text style={styles.text}>
+            age:{props.route.params.userdata?.age}
+          </Text>
         </View>
       </View>
     </View>

--- a/screens/UserDetailsScreen.tsx
+++ b/screens/UserDetailsScreen.tsx
@@ -27,15 +27,11 @@ export const UserDetailsScreen = (props: Props) => {
         </View>
         <View style={styles.userdata}>
           <Text style={styles.label}>email:</Text>
-          <Text style={styles.text}>
-            email:{props.route?.params?.userdata?.email}
-          </Text>
+          <Text style={styles.text}>{props.route.params.userdata?.email}</Text>
         </View>
         <View style={styles.userdata}>
           <Text style={styles.label}>age:</Text>
-          <Text style={styles.text}>
-            age:{props.route.params.userdata?.age}
-          </Text>
+          <Text style={styles.text}>{props.route.params.userdata?.age}</Text>
         </View>
       </View>
     </View>

--- a/screens/UserDetailsScreen.tsx
+++ b/screens/UserDetailsScreen.tsx
@@ -17,7 +17,7 @@ export const UserDetailsScreen = (props: Props) => {
   return (
     <View style={styles.container}>
       <Image
-        source={{ uri: props.route.params.userdata?.thumbnailUrl }}
+        source={{ uri: props.route.params.userdata?.pictureUrl }}
         style={{ width: 200, height: 200 }}
       />
       <View style={styles.userDetails}>

--- a/screens/UserDetailsScreen.tsx
+++ b/screens/UserDetailsScreen.tsx
@@ -17,21 +17,21 @@ export const UserDetailsScreen = (props: Props) => {
   return (
     <View style={styles.container}>
       <Image
-        source={{ uri: props.route.params.userdata?.pictureUrl }}
+        source={{ uri: props.route.params.userData?.pictureUrl }}
         style={{ width: 200, height: 200 }}
       />
       <View style={styles.userDetails}>
         <View style={styles.userdata}>
           <Text style={styles.label}>name:</Text>
-          <Text style={styles.text}>{props.route.params.userdata?.name}</Text>
+          <Text style={styles.text}>{props.route.params.userData?.name}</Text>
         </View>
         <View style={styles.userdata}>
           <Text style={styles.label}>email:</Text>
-          <Text style={styles.text}>{props.route.params.userdata?.email}</Text>
+          <Text style={styles.text}>{props.route.params.userData?.email}</Text>
         </View>
         <View style={styles.userdata}>
           <Text style={styles.label}>age:</Text>
-          <Text style={styles.text}>{props.route.params.userdata?.age}</Text>
+          <Text style={styles.text}>{props.route.params.userData?.age}</Text>
         </View>
       </View>
     </View>

--- a/screens/UserDetailsScreen.tsx
+++ b/screens/UserDetailsScreen.tsx
@@ -17,7 +17,7 @@ export const UserDetailsScreen = (props: Props) => {
   return (
     <View style={styles.container}>
       <Image
-        source={{ uri: props.route.params.userdata?.thumbnail }}
+        source={{ uri: props.route.params.userdata?.thumbnailUrl }}
         style={{ width: 200, height: 200 }}
       />
       <View style={styles.userDetails}>

--- a/screens/UserDetailsScreen.tsx
+++ b/screens/UserDetailsScreen.tsx
@@ -1,0 +1,62 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
+import { Image, StyleSheet, Text, View } from "react-native";
+import { RootStackParamList } from "../App";
+
+type Props = NativeStackScreenProps<RootStackParamList, "UserDetailsScreen">;
+
+/** @package */
+export const UserDetailsScreen = (props: Props) => {
+  if (!props) {
+    return (
+      <View>
+        <Text>データが見つかりませんでした</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Image
+        source={{ uri: props.route.params.userdata.thumbnail }}
+        style={{ width: 200, height: 200 }}
+      />
+      <View style={styles.userDetails}>
+        <View style={styles.userdata}>
+          <Text style={styles.label}>name:</Text>
+          <Text style={styles.text}>{props.route.params.userdata.name}</Text>
+        </View>
+        <View style={styles.userdata}>
+          <Text style={styles.label}>email:</Text>
+          <Text style={styles.text}>
+            email:{props.route.params.userdata.email}
+          </Text>
+        </View>
+        <View style={styles.userdata}>
+          <Text style={styles.label}>age:</Text>
+          <Text style={styles.text}>age:{props.route.params.userdata.age}</Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  userDetails: {
+    display: "flex",
+    flexDirection: "column",
+    padding: 10,
+    maxWidth: 300,
+  },
+  userdata: {
+    margin: 3,
+  },
+  label: { fontSize: 16 },
+  text: {
+    fontSize: 16,
+  },
+});

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -17,6 +17,7 @@ export type UserData = {
   thumbnailUrl: string;
   email: string;
   age: string;
+  pictureUrl: string;
 };
 
 /** @package */
@@ -38,6 +39,7 @@ export const UserListScreen = ({ navigation }: Props) => {
           thumbnailUrl: data.picture.thumbnail,
           email: data.email,
           age: data.dob.age,
+          pictureUrl: data.picture.large,
         };
       });
       setUserData(userData);

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -58,7 +58,7 @@ export const UserListScreen = ({ navigation }: Props) => {
     );
   }
 
-  if (userData === []) {
+  if (userData.length === 0) {
     return (
       <View>
         <Text>データが見つかりませんでした</Text>
@@ -66,8 +66,8 @@ export const UserListScreen = ({ navigation }: Props) => {
     );
   }
 
-  const onPressUserDetails = (userdata: any) => {
-    navigation.navigate("UserDetailsScreen", { userdata: userdata });
+  const onPressUserDetails = (data: any) => {
+    navigation.navigate("UserDetailsScreen", { userdata: data });
   };
 
   return (

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -1,6 +1,13 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useCallback, useEffect, useState } from "react";
-import { FlatList, Image, StyleSheet, Text, View } from "react-native";
+import {
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { RootStackParamList } from "../App";
 
 type Props = NativeStackScreenProps<RootStackParamList, "UserListScreen">;
@@ -76,11 +83,16 @@ export const UserListScreen = ({ navigation }: Props) => {
             flexDirection: "row",
           }}
         >
-          <Image
-            source={{ uri: item.thumbnailUrl }}
-            style={{ width: 40, height: 40 }}
-          />
-          <Text style={styles.item}>{item.name}</Text>
+          <TouchableOpacity
+            style={styles.item}
+            onPress={() => onPressUserDetails(item)}
+          >
+            <Image
+              source={{ uri: item.thumbnailUrl }}
+              style={{ width: 40, height: 40 }}
+            />
+            <Text style={styles.text}>{item.name}</Text>
+          </TouchableOpacity>
         </View>
       )}
     />

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -14,7 +14,7 @@ type Props = NativeStackScreenProps<RootStackParamList, "UserListScreen">;
 
 export type UserData = {
   name: string;
-  thumbnail: string;
+  thumbnailUrl: string;
   email: string;
   age: string;
 };
@@ -35,7 +35,7 @@ export const UserListScreen = ({ navigation }: Props) => {
       const userData = users.results.map((data: any) => {
         return {
           name: data.name.first,
-          thumbnail: data.picture.thumbnail,
+          thumbnailUrl: data.picture.thumbnail,
           email: data.email,
           age: data.dob.age,
         };
@@ -86,7 +86,7 @@ export const UserListScreen = ({ navigation }: Props) => {
               onPress={() => onPressUserDetails(item)}
             >
               <Image
-                source={{ uri: item.thumbnail }}
+                source={{ uri: item.thumbnailUrl }}
                 style={{ width: 40, height: 40 }}
               />
               <Text style={styles.text}>{item.name}</Text>

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -1,13 +1,6 @@
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useCallback, useEffect, useState } from "react";
-import {
-  FlatList,
-  Image,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { FlatList, Image, StyleSheet, Text, View } from "react-native";
 import { RootStackParamList } from "../App";
 
 type Props = NativeStackScreenProps<RootStackParamList, "UserListScreen">;
@@ -84,7 +77,7 @@ export const UserListScreen = ({ navigation }: Props) => {
           }}
         >
           <Image
-            source={{ uri: item.thumbnail }}
+            source={{ uri: item.thumbnailUrl }}
             style={{ width: 40, height: 40 }}
           />
           <Text style={styles.item}>{item.name}</Text>

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -12,12 +12,16 @@ import { RootStackParamList } from "../App";
 
 type Props = NativeStackScreenProps<RootStackParamList, "UserListScreen">;
 
+export type UserData = {
+  name: string;
+  thumbnail: string;
+  email: string;
+  age: string;
+};
+
 /** @package */
 export const UserListScreen = ({ navigation }: Props) => {
-  const [userData, setUserData] =
-    useState<
-      { name: string; thumbnail: string; email: string; age: string }[]
-    >();
+  const [userData, setUserData] = useState<UserData[]>();
 
   const callUserDataApi = useCallback(async () => {
     const res = await fetch("https://randomuser.me/api/?results=10");

--- a/screens/UserListScreen.tsx
+++ b/screens/UserListScreen.tsx
@@ -1,8 +1,19 @@
+import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { useCallback, useEffect, useState } from "react";
-import { FlatList, Image, StyleSheet, Text, View } from "react-native";
+import {
+  FlatList,
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { RootStackParamList } from "../App";
+
+type Props = NativeStackScreenProps<RootStackParamList, "UserListScreen">;
 
 /** @package */
-export const UserListScreen = () => {
+export const UserListScreen = ({ navigation }: Props) => {
   const [userData, setUserData] =
     useState<
       { name: string; thumbnail: string; email: string; age: string }[]
@@ -49,6 +60,10 @@ export const UserListScreen = () => {
     );
   }
 
+  const onPressUserDetails = (userdata: any) => {
+    navigation.navigate("UserDetailsScreen", { userdata: userdata });
+  };
+
   return (
     //ScrollViewの中にFlatListはおかない
     <View style={styles.container}>
@@ -62,11 +77,16 @@ export const UserListScreen = () => {
               flexDirection: "row",
             }}
           >
-            <Image
-              source={{ uri: item.thumbnail }}
-              style={{ width: 40, height: 40 }}
-            />
-            <Text style={styles.item}>{item.name}</Text>
+            <TouchableOpacity
+              style={styles.item}
+              onPress={() => onPressUserDetails(item)}
+            >
+              <Image
+                source={{ uri: item.thumbnail }}
+                style={{ width: 40, height: 40 }}
+              />
+              <Text style={styles.text}>{item.name}</Text>
+            </TouchableOpacity>
           </View>
         )}
       />
@@ -80,8 +100,13 @@ const styles = StyleSheet.create({
     paddingTop: 22,
   },
   item: {
-    padding: 10,
-    fontSize: 18,
+    display: "flex",
+    flexDirection: "row",
     height: 44,
+    alignItems: "center",
+  },
+  text: {
+    fontSize: 20,
+    paddingLeft: 10,
   },
 });

--- a/screens/index.ts
+++ b/screens/index.ts
@@ -1,1 +1,2 @@
+export * from "./UserDetailsScreen";
 export * from "./UserListScreen";


### PR DESCRIPTION


## 対応 issue

fixes #2 
close #2 

(すみませんブランチ名とちぐはぐになっています）

## 実装内容、変更点

- ユーザー一覧ページで取得したdataを利用してユーザー詳細ページを表示
- CSSの修正は別で行います🙇‍♀️

## スクリーンショット
<img width="572" alt="スクリーンショット 2022-10-28 15 59 51" src="https://user-images.githubusercontent.com/74912714/198523844-dc4f6334-678e-4db3-aab4-bda58ff58d89.png">


## 機能テスト

- [x] UserListでユーザーをクリックすると上記のスクリーンショットのようなページが表示されていることを確認
- [x] アイコン,名前,年齢,メールアドレスが表示されていること(要件を満たしていること)

## その他

